### PR TITLE
Remove Docker HUB

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,8 @@
 # php-nightly
 A container image with the nightly version of the PHP (in development) to test the new features, give feedback and keep CI looking for upgrading issues.
 
-## Docker HUB
-
-```bash
-docker run -it --rm codelicia/php-nightly:latest php --version
-```
-
 ## Github Registry
 
 ```bash
-docker run -it --rm ⁨ghcr.io/codelicia/php-nightly:master php --version
+docker run -it --rm ghcr.io/codelicia/php-nightly:master php --version
 ```


### PR DESCRIPTION
Docker HUB is not being published for a while.

It is also fixing the command to run from Github Registry by removing a special char.